### PR TITLE
sandbox: Update sandbox OpenAPI spec

### DIFF
--- a/sandbox/openapi.yml
+++ b/sandbox/openapi.yml
@@ -680,10 +680,9 @@ components:
         Kodo bucket resource mounted into the sandbox via NFS.
         The platform creates an NFS-backed proxy that maps the Kodo bucket to a local path inside the sandbox.
         Credentials (access_key/secret_key) are never exposed inside the sandbox.
+        Note: Kodo resource is only supported when creating a sandbox with Qiniu AKSK authentication. API key authentication is not supported.
       required:
         - type
-        - access_key
-        - secret_key
         - bucket
         - mount_path
       properties:
@@ -692,14 +691,6 @@ components:
           enum:
             - kodo
           description: Resource type identifier
-        access_key:
-          type: string
-          writeOnly: true
-          description: Kodo access key ID
-        secret_key:
-          type: string
-          writeOnly: true
-          description: Kodo secret access key
         bucket:
           type: string
           description: Kodo bucket name


### PR DESCRIPTION
## What changed

- Sync `sandbox/openapi.yml` from the latest sandbox public OpenAPI spec.
- Remove `access_key` and `secret_key` from the Kodo resource schema.
- Document that Kodo resources only support Qiniu AKSK authentication when creating a sandbox.

## Why

The upstream sandbox spec no longer exposes per-resource Kodo AK/SK fields. The API specs repo should match the latest public sandbox OpenAPI definition.

## Validation

- `cmp -s sandbox/openapi.yml /Users/miclle/workspace/qbox/sandbox/spec/openapi-public.yml`
- `ruby -ryaml -e 'data = YAML.load_file("sandbox/openapi.yml"); puts [data["openapi"], data.dig("info", "title")].compact.join(" ")'`
- `git diff --check -- sandbox/openapi.yml`
