### PR TITLE
feat(sandbox): update public OpenAPI spec

### DIFF
--- a/sandbox/openapi.yml
+++ b/sandbox/openapi.yml
@@ -1013,6 +1013,7 @@ components:
         - updatedAt
         - lastSpawnedAt
         - spawnCount
+        - isOwner
         - builds
       properties:
         templateID:
@@ -1043,9 +1044,12 @@ components:
           type: integer
           format: int64
           description: Number of times the template was used
+        isOwner:
+          type: boolean
+          description: Whether the template is owned by the requesting team
         builds:
           type: array
-          description: List of builds for the template
+          description: List of builds for the template (empty for non-owning teams)
           items:
             $ref: "#/components/schemas/TemplateBuild"
     TemplateAliasResponse:
@@ -1522,6 +1526,16 @@ paths:
           required: false
           schema:
             type: string
+        - name: template
+          in: query
+          description: Filter sandboxes by one or more template IDs or aliases. Maximum 20 values.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: false
         - name: state
           in: query
           description: Filter sandboxes by one or more states
@@ -2008,7 +2022,7 @@ paths:
   /templates/{templateID}:
     get:
       operationId: getTemplate
-      description: Get template details
+      description: Get template details. Returns the template owned by the caller's team, or a public template owned by the default templates team (when server-side default templates are configured). Builds are only included when the requesting team owns the template.
       tags: [templates]
       security:
         - ApiKeyAuth: []
@@ -2286,7 +2300,7 @@ paths:
   /templates/aliases/{alias}:
     get:
       operationId: getTemplateByAlias
-      description: Check if template with given alias exists
+      description: Resolve a template alias. Returns the template ID and visibility for the given alias, if accessible to the caller's team. Also resolves aliases of public templates owned by the default templates team (when server-side default templates are configured).
       tags: [templates]
       security:
         - ApiKeyAuth: []


### PR DESCRIPTION
## Summary

- sync `sandbox/openapi.yml` with the latest sandbox public OpenAPI specification
- expose template ownership metadata and clarify build visibility for non-owning teams
- add sandbox template filtering and document public template lookup behavior

## Why

Keep `qiniu/api-specs` aligned with the sandbox public API contract so downstream SDK generation reflects the latest supported fields and query parameters.

## Impact

Downstream SDK generators can consume the new `isOwner` field and `template` filter, while template lookup documentation now reflects public default-template behavior. This PR changes only the OpenAPI specification.

## Validation

- source and target files are byte-for-byte identical and share the same SHA-256
- `sandbox/openapi.yml` parses successfully as YAML
- `git diff --check upstream/main...HEAD` passes
